### PR TITLE
fix: Iterating over pid_cpu_usage dictionary

### DIFF
--- a/procfs_sensor/__main__.py
+++ b/procfs_sensor/__main__.py
@@ -79,7 +79,7 @@ def sensor_mesure_send(sampling_interval, sensor, target, sock):
     cgroup_cpu_usage = {}
     global_cpu_usage = 0
 
-    for process, _ in pid_cpu_usage:
+    for process in pid_cpu_usage:
         global_cpu_usage += float(pid_cpu_usage[process].replace(", ", "."))
 
     for cgroup in target:


### PR DESCRIPTION
The code tries to iterate over pid_cpu_usage in line 82, but uses an incorrect method to iterate giving rise to the error: ValueError: not enough values to unpack (expected 2, got 1)